### PR TITLE
SWARM-733: Generator does not honor group/artifact id for package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,12 @@
          <artifactId>thymeleaf</artifactId>
          <version>3.0.1.RELEASE</version>
       </dependency>
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+         <version>4.12</version>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
    <profiles>

--- a/src/main/java/org/swarm/generator/rest/EndpointFilePathGenerator.java
+++ b/src/main/java/org/swarm/generator/rest/EndpointFilePathGenerator.java
@@ -1,0 +1,44 @@
+package org.swarm.generator.rest;
+
+/**
+ * Generates the file path and package of a sample JAXRS service based upon the
+ * Maven groupId and artifactId.
+ *
+ * The JAXRS service is created at groupid.artifactId.rest.HelloWorldEndpoint.java
+ *
+ * Non alpha-numeric characters are stripped from the generated package name
+ */
+class EndpointFilePathGenerator {
+
+    private static final String SRC_PATH = "/src/main/java";
+    private static final String REST_CLASS = "/rest/HelloWorldEndpoint.java";
+    private static final String REST_PACKAGE = "rest";
+
+    private final String endpointFilePath;
+    private final String endpointPackage;
+
+    EndpointFilePathGenerator(String groupId, String artifactId) {
+
+        groupId = groupId.replaceAll("[^A-Za-z0-9.]", "");
+        artifactId = artifactId.replaceAll("[^A-Za-z0-9]", "");
+
+        endpointFilePath = String.format("%s/%s/%s%s",
+                SRC_PATH,
+                groupId.replace(".", "/"),
+                artifactId,
+                REST_CLASS);
+
+        endpointPackage = String.format("%s.%s.%s",
+                groupId,
+                artifactId,
+                REST_PACKAGE);
+    }
+
+    String getEndpointFilePath() {
+        return endpointFilePath;
+    }
+
+    String getEndpointPackage() {
+        return endpointPackage;
+    }
+}

--- a/src/main/resources/templates/HelloWorldEndpoint.tl.java
+++ b/src/main/resources/templates/HelloWorldEndpoint.tl.java
@@ -1,4 +1,4 @@
-package com.example.rest;
+package [# th:utext="${endpointPackage}"/];
 
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;

--- a/src/test/java/org/swarm/generator/rest/EndpointFilePathGeneratorTest.java
+++ b/src/test/java/org/swarm/generator/rest/EndpointFilePathGeneratorTest.java
@@ -1,0 +1,40 @@
+package org.swarm.generator.rest;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EndpointFilePathGeneratorTest {
+
+    @Test
+    public void shouldGeneratePathForValidGroupAndArtifact() {
+        EndpointFilePathGenerator endpointFilePathGenerator = new EndpointFilePathGenerator("com.test", "example");
+
+        assertEquals("/src/main/java/com/test/example/rest/HelloWorldEndpoint.java",
+                endpointFilePathGenerator.getEndpointFilePath());
+    }
+
+    @Test
+    public void shouldStripNonAlphaNumericFromGroupAndArtifact() {
+        EndpointFilePathGenerator endpointFilePathGenerator = new EndpointFilePathGenerator("com.my-test", "example-app");
+
+        assertEquals("/src/main/java/com/mytest/exampleapp/rest/HelloWorldEndpoint.java",
+                endpointFilePathGenerator.getEndpointFilePath());
+    }
+
+    @Test
+    public void shouldGenerateEndpointPackageForValidGroupAndArtifact() {
+        EndpointFilePathGenerator endpointFilePathGenerator = new EndpointFilePathGenerator("com.test", "example");
+
+        assertEquals("com.test.example.rest",
+                endpointFilePathGenerator.getEndpointPackage());
+    }
+
+    @Test
+    public void shouldStripNonAlphaNumericFromEndpointPackage() {
+        EndpointFilePathGenerator endpointFilePathGenerator = new EndpointFilePathGenerator("com.my-test", "example-app");
+
+        assertEquals("com.mytest.exampleapp.rest",
+                endpointFilePathGenerator.getEndpointPackage());
+    }
+}


### PR DESCRIPTION
## Motivation

This commit is required to change the WildFly Swarm Generator application to take into account the maven
groupId and artifactId when creating a project that includes JAXRS resources.  In this situation, an example
JAXRS endpoint is created in a package appropriate to the specified groupId and artifactId.

The package for the generated JAXRS endpoint was discussed on the WildFly Swarm mailing list.
## Modifications

The ProjectGeneratorResource has been modified to have two ClassLoaderTemplateResolvers so that both the pom.tl.xml template
and the HelloWorldEndpoint.tl.java can successfuly be generated.  Thymeleaf requires two template resolvers as these files have
different template modes (XML and TEXT respectively).

A new class, EndpointFilePathGenerator (and associated tests) has been created to aid with the construction of the
path to the example rest end point.  This class is responsible for generating the endpoint path and stripping all non
alpha-numeric characters form the package name.

The HelloWorldEndpoint.tl.java template has been modified to merge the newly generated package.
## Result

This commit changes the WildFly Swarm Generator application to use a sensible package name for the example JAXRS
endpoint created for project containing JAXRS.
